### PR TITLE
Make it possible to disable validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,8 @@ function cached(expr, placeholders) {
 }
 
 function assert(val, type, name, ...placeholders) {
+  if (assert.disabled) return val;
+
   if (typeof name !== 'string' || name === '') {
     throw new Error('Empty name for assertion')
   }
@@ -166,3 +168,4 @@ function message(val, name, msg = 'Invalid value') {
 
 module.exports = assert
 assert.parse = parse
+assert.disabled = false;

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,9 @@ class Example {
 
 The first three arguments are required. Throws if `value` does not pass `assertion`. Otherwise, returns `value`. The `name` will be used in the error message.
 
+## `t.disabled` (defaults to `false`)
+If set to `true` will disable validation entirely. This can be useful if you don't want the overhead in production environments.
+
 ### assertions
 
 If `assertion` is a string or regular expression, it will be treated as a type expression (see below). If it's a function, it will receive the value and should return `false` if the value is invalid. A boolean `assertion` works like `assert(assertion === true)`. If `assertion` is an array, each element must pass assertion. For example, to assert that an argument is a number and greater than two: `t(arg, ['n', (v) => v > 2 ], 'arg')`.


### PR DESCRIPTION
Sometimes it's useful to have validation in development environments, but not worth the overhead in production. This pull request will make it super easy to do something like this in a backwards compatible way:

``` js
var t = require('mini-type-assert');
t.disabled === process.env.NODE_ENV === 'production';

// your code here
```
